### PR TITLE
Read documents as arrays instead of objects

### DIFF
--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -37,7 +37,7 @@ class RestController extends AbstractRestController implements
         }
 
         if ($row) {
-            return $this->renderRest($request, $row, Response::HTTP_OK);
+            return $this->renderRest($request, $row[0], Response::HTTP_OK);
         } else {
             return $this->renderError($request, 'Document does not exist', Response::HTTP_NOT_FOUND);
         }

--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -73,7 +73,7 @@ class RestController extends AbstractRestController implements
 
         $id = $response['items'][0]['create']['_id'];
         $row = $this->getCrud()->read($repository, $id);
-        return $this->renderRest($request, $row, Response::HTTP_CREATED);
+        return $this->renderRest($request, $row[0], Response::HTTP_CREATED);
     }
 
     /**

--- a/Service/Crud.php
+++ b/Service/Crud.php
@@ -15,8 +15,6 @@ use Elasticsearch\Common\Exceptions\NoDocumentsToGetException;
 use ONGR\ElasticsearchBundle\Result\Result;
 use ONGR\ElasticsearchBundle\Service\Repository;
 use ONGR\ElasticsearchDSL\Query\IdsQuery;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
-use ONGR\ElasticsearchDSL\Search;
 
 /**
  * Simple CRUD operations service.
@@ -29,7 +27,6 @@ class Crud implements CrudInterface
      */
     public function create(Repository $repository, array $data)
     {
-
         if (!empty($data['_id']) && $this->read($repository, $data['_id'])) {
             throw new \RuntimeException('The resource existed.');
         }

--- a/Service/Crud.php
+++ b/Service/Crud.php
@@ -14,6 +14,7 @@ namespace ONGR\ApiBundle\Service;
 use Elasticsearch\Common\Exceptions\NoDocumentsToGetException;
 use ONGR\ElasticsearchBundle\Result\Result;
 use ONGR\ElasticsearchBundle\Service\Repository;
+use ONGR\ElasticsearchDSL\Query\IdsQuery;
 use ONGR\ElasticsearchDSL\Query\TermQuery;
 use ONGR\ElasticsearchDSL\Search;
 
@@ -41,8 +42,9 @@ class Crud implements CrudInterface
      */
     public function read(Repository $repository, $id)
     {
-        $search = new Search();
-        $search->addQuery(new TermQuery('_id', $id));
+        $search = $repository->createSearch();
+        $search->addQuery(new IdsQuery([$id]));
+        $search->setSize(1);
 
         return $repository->execute($search, Result::RESULTS_ARRAY);
     }

--- a/Service/Crud.php
+++ b/Service/Crud.php
@@ -12,7 +12,10 @@
 namespace ONGR\ApiBundle\Service;
 
 use Elasticsearch\Common\Exceptions\NoDocumentsToGetException;
+use ONGR\ElasticsearchBundle\Result\Result;
 use ONGR\ElasticsearchBundle\Service\Repository;
+use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Search;
 
 /**
  * Simple CRUD operations service.
@@ -38,7 +41,10 @@ class Crud implements CrudInterface
      */
     public function read(Repository $repository, $id)
     {
-        return $repository->find($id);
+        $search = new Search();
+        $search->addQuery(new TermQuery('_id', $id));
+
+        return $repository->execute($search, Result::RESULTS_ARRAY);
     }
 
     /**


### PR DESCRIPTION
Current serialiser does not work with objects having iterators inside.