### PR TITLE
Put and delete in batch mode.

### DIFF
--- a/Controller/BatchController.php
+++ b/Controller/BatchController.php
@@ -20,12 +20,12 @@ use Symfony\Component\HttpFoundation\Response;
 class BatchController extends AbstractRestController
 {
     /**
-     * Main action to process batch call.
+     * Action to process create batch call.
      *
      * @param Request $request
      * @return Response
      */
-    public function processAction(Request $request)
+    public function postAction(Request $request)
     {
         $crud = $this->getCrudService();
         $repository = $this->getRequestRepository($request);
@@ -34,6 +34,54 @@ class BatchController extends AbstractRestController
         try {
             foreach ($documents as $document) {
                 $crud->create($repository, $document);
+            }
+            $crud->commit($repository);
+            return $this->renderRest($request, '', Response::HTTP_NO_CONTENT);
+        } catch (\Exception $e) {
+            return $this->renderError($request, $e->getMessage(), Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Action to process upsert batch call.
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function putAction(Request $request)
+    {
+        $crud = $this->getCrudService();
+        $repository = $this->getRequestRepository($request);
+        $documents = $this->get('ongr_api.request_serializer')->deserializeRequest($request);
+
+        try {
+            foreach ($documents as $document) {
+                $id = $document['_id'];
+                unset($document['_id']);
+                $crud->update($repository, $id, $document);
+            }
+            $crud->commit($repository);
+            return $this->renderRest($request, '', Response::HTTP_NO_CONTENT);
+        } catch (\Exception $e) {
+            return $this->renderError($request, $e->getMessage(), Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Action to process delete batch call.
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function deleteAction(Request $request)
+    {
+        $crud = $this->getCrudService();
+        $repository = $this->getRequestRepository($request);
+        $documents = $this->get('ongr_api.request_serializer')->deserializeRequest($request);
+
+        try {
+            foreach ($documents as $document) {
+                $crud->delete($repository, $document['_id']);
             }
             $crud->commit($repository);
             return $this->renderRest($request, '', Response::HTTP_NO_CONTENT);

--- a/Resources/doc/endpoints.md
+++ b/Resources/doc/endpoints.md
@@ -38,13 +38,13 @@ ongr_api:
 ```
 > By default batch is enabled but if you don't want to allow multiple documents insert, you can disable it.
 
-To index multiple documents sent POST request to the new `_batch` endpoint. By provided example above it should look like this:
+To index multiple documents send either a POST or PUT request, or delete multiple documents by sending a DELETE request, to the new `_batch` endpoint. By provided example above it should look like this:
 
 ```
 <yourdomain.com>/api/v3/product/_batch 
 ```
 
-This API endpoint only takes **POST** requests and in specific structure. f.e.
+This API endpoint takes requests bodies in a specific structure. f.e.
 
 ```json
 [
@@ -62,6 +62,8 @@ This API endpoint only takes **POST** requests and in specific structure. f.e.
 ]
 ```
 
+Note that both PUT and DELETE will require you to send the _id for every document.
+
 API will return a response with created products ID's if no error occurs. e.g. response:
 
 ```json
@@ -70,6 +72,14 @@ API will return a response with created products ID's if no error occurs. e.g. r
     "SS10043"
 ]
 ```
+
+### Overview
+
+| Method | Full document body | _id field  | Resulting Action              |
+|--------|--------------------|------------|-------------------------------|
+| POST   | required           | Optional   | Creation, no update           |
+| PUT    | required           | Required   | Update, creation if necessary |
+| DELETE | will be ignored    | Required   | Deletion                      |
 
 
 ## Get all documents

--- a/Routing/ElasticsearchLoader.php
+++ b/Routing/ElasticsearchLoader.php
@@ -72,7 +72,7 @@ class ElasticsearchLoader extends Loader
         $endpoint,
         $version = 'v1'
     ) {
-    
+
         $defaults = [
             '_documentId' => null,
             '_endpoint' => $endpoint,
@@ -83,18 +83,20 @@ class ElasticsearchLoader extends Loader
         $pattern = $version . '/' . sprintf('%s/{documentId}', strtolower($document));
 
         if ($endpoint['batch']) {
-            $defaults['_controller'] = 'ONGRApiBundle:Batch:Process';
-            $batchPattern = $version . '/' . sprintf('%s', strtolower($document)) . '/_batch';
-            $name = strtolower(sprintf('ongr_api_%s_%s_%s', $version, $document, Request::METHOD_POST));
-            $collection->add($name . '_batch', new Route(
-                $batchPattern,
-                $defaults,
-                [],
-                [],
-                "",
-                [],
-                [Request::METHOD_POST]
-            ));
+            foreach ([Request::METHOD_PUT, Request::METHOD_POST, Request::METHOD_DELETE] as $method) {
+                $defaults['_controller'] = 'ONGRApiBundle:Batch:' . ucfirst(strtolower($method));
+                $batchPattern = $version . '/' . sprintf('%s', strtolower($document)) . '/_batch';
+                $name = strtolower(sprintf('ongr_api_%s_%s_%s', $version, $document, $method));
+                $collection->add($name . '_batch', new Route(
+                    $batchPattern,
+                    $defaults,
+                    [],
+                    [],
+                    "",
+                    [],
+                    [$method]
+                ));
+            }
         }
 
         foreach ($endpoint['methods'] as $method) {

--- a/Routing/ElasticsearchLoader.php
+++ b/Routing/ElasticsearchLoader.php
@@ -100,7 +100,6 @@ class ElasticsearchLoader extends Loader
         }
 
         foreach ($endpoint['methods'] as $method) {
-
             $name = strtolower(sprintf('ongr_api_%s_%s_%s', $version, $document, $method));
             $defaults['_controller'] = sprintf('ONGRApiBundle:Rest:%s', strtolower($method));
 

--- a/Service/Crud.php
+++ b/Service/Crud.php
@@ -56,7 +56,7 @@ class Crud implements CrudInterface
      */
     public function update(Repository $repository, $id, array $data)
     {
-        $repository->getManager()->bulk('update', $repository->getType(), ['_id' => $id, 'doc' => $data]);
+        $repository->getManager()->bulk('update', $repository->getType(), ['_id' => $id, 'doc' => $data, 'doc_as_upsert' => true]);
     }
 
     /**

--- a/Service/Crud.php
+++ b/Service/Crud.php
@@ -56,7 +56,15 @@ class Crud implements CrudInterface
      */
     public function update(Repository $repository, $id, array $data)
     {
-        $repository->getManager()->bulk('update', $repository->getType(), ['_id' => $id, 'doc' => $data, 'doc_as_upsert' => true]);
+        $repository->getManager()->bulk(
+            'update',
+            $repository->getType(),
+            [
+                '_id' => $id,
+                'doc' => $data,
+                'doc_as_upsert' => true
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
Batch versions of PUT and DELETE would be useful., as some project might only do updates in bulk (e.g. when you have an OXID feed via the OXERP interface).
Both new actions take the same body format as POST, with DELETE only taking the _id and dropping everything else.
I also changed the update method of `Crud` the do upserts instead, as this is more logical in a rest environment than an error message for non-existing documents (or, like now, to fail silently)